### PR TITLE
Force section .libc.data for impure_ptr on PIC32

### DIFF
--- a/newlib/libc/include/sys/config.h
+++ b/newlib/libc/include/sys/config.h
@@ -129,7 +129,7 @@
 #if defined(__mips__) && !defined(__rtems__) && !defined(__PIC32)
 #define __ATTRIBUTE_IMPURE_PTR__ __attribute__((__section__(".sdata")))
 #elif defined(__PIC32)
-#define __ATTRIBUTE_IMPURE_PTR__ 
+#define __ATTRIBUTE_IMPURE_PTR__  __attribute__((section(".libc.data")))
 #endif
 
 #ifdef __xstormy16__


### PR DESCRIPTION
This change prevents conflicts between where _impure_ptr is located and where an application may attempt to access it.
